### PR TITLE
Add input specific style variables

### DIFF
--- a/app/styles/hex/_field.scss
+++ b/app/styles/hex/_field.scss
@@ -11,7 +11,7 @@
 
       &:focus,
       &.focus {
-        box-shadow: 0 0 0 $focus-shadow-width rgba($danger, $focus-shadow-opacity);
+        box-shadow: $input-focus-shadow-invalid;
       }
     }
   }
@@ -34,13 +34,15 @@
   width: 100%;
   height: 2.375rem;
   padding: .375rem .5rem 7px; // center the text
-  font-size: $font-size-sm;
+  font-size: $input-font-size;
   line-height: $input-line-height;
-  color: $text;
-  background-color: $gray-50;
+  color: $input-color;
+  background-color: $input-background-color;
   background-clip: padding-box;
-  border: .125rem solid $gray-400;
-  border-radius: $border-radius;
+  border-color: $input-border-color;
+  border-style: solid;
+  border-width: $input-border-width;
+  border-radius: $input-border-radius;
 
   // Un-style the caret on `<select>`s in IE10+.
   &::-ms-expand {
@@ -54,10 +56,10 @@
     background-color: $white;
     border-color: $primary;
     outline: 0;
-    box-shadow: $focus-shadow;
+    box-shadow: $input-focus-shadow;
 
     &.invalid {
-      box-shadow: 0 0 0 $focus-shadow-width rgba($danger, $focus-shadow-opacity);
+      box-shadow: $input-focus-shadow-invalid;
     }
   }
 
@@ -109,7 +111,7 @@ select.field-control {
   padding: .25rem .5rem;
   font-size: $font-size-xs;
   line-height: 1.5;
-  border-radius: $border-radius-sm;
+  border-radius: $input-border-radius-sm;
 }
 
 .field-control-lg {
@@ -117,7 +119,7 @@ select.field-control {
   padding: .675rem 1rem;
   font-size: $font-size;
   line-height: 1.5;
-  border-radius: $border-radius-lg;
+  border-radius: $input-border-radius-lg;
 }
 
 select.field-control {

--- a/app/styles/hex/_variables.scss
+++ b/app/styles/hex/_variables.scss
@@ -61,7 +61,19 @@ $font-size-xs:               ($font-size * .75) !default;
 
 $font-weight:                400 !default;
 $line-height:                1.5 !default;
-$input-line-height:          1.25rem/$font-size-sm !default;
+
+// Fields
+$input-color:                $text !default;
+$input-font-size:            $font-size-sm !default;
+$input-line-height:          1.25rem/$input-font-size !default;
+$input-background-color:     $gray-50 !default;
+$input-border-color:         $gray-400 !default;
+$input-border-radius:        $border-radius !default;
+$input-border-radius-sm:     $border-radius-sm !default;
+$input-border-radius-lg:     $border-radius-lg !default;
+$input-border-width:         .125rem !default;
+$input-focus-shadow:         $focus-shadow !default;
+$input-focus-shadow-invalid: 0 0 0 $focus-shadow-width rgba($danger, $focus-shadow-opacity) !default;
 
 // Links
 $link-color:                 $primary !default;

--- a/tests/dummy/app/docs/components/search-field/template.md
+++ b/tests/dummy/app/docs/components/search-field/template.md
@@ -9,6 +9,7 @@ In that case, the action will be called with the new value.
   {{#demo.example name="search-field-example.hbs"}}
     <SearchField 
       @value={{this.model}}
+      @onChange={{fn (mut this.model)}}
       placeholder="Search the users..."
       class="custom-class"
     />


### PR DESCRIPTION
This should be enough to cover the input styles. Here is an example for create rectangular inputs:

```sass
$input-border-width:         1px; // .125rem !default;
$input-border-radius:        0; // $border-radius !default;
$input-border-radius-sm:     0; // $border-radius-sm !default;
$input-border-radius-lg:     0; // $border-radius-lg !default;
$input-focus-shadow:         0 0 0 1px $primary inset;  // $focus-shadow !default;
$input-focus-shadow-invalid: 0 0 0 1px $danger inset; // 0 0 0 $focus-shadow-width rgba($danger, $focus-shadow-opacity) !default;
```