### PR TITLE
Better handle cases with the modal and Ember Basic Dropdown

### DIFF
--- a/app/styles/hex/_blanket.scss
+++ b/app/styles/hex/_blanket.scss
@@ -9,7 +9,7 @@
   bottom: 0;
   left: 0;
   opacity: 0;
-  z-index: 1000;
+  z-index: 960;
 }
 
 .blanket-tinted {

--- a/index.js
+++ b/index.js
@@ -5,17 +5,15 @@ module.exports = {
 
   contentFor(type, config) {
     let emberBasicDropdown = this.addons.find((a) => a.name === 'ember-basic-dropdown');
-    let emberBasicDropdownContentFor = emberBasicDropdown.contentFor(type, config);
+    let emberBasicDropdownContentFor = emberBasicDropdown.contentFor(type, config) || '';
 
     if (config.environment !== 'test' && type === 'body-footer' && !config._hexContentForInvoked) {
       config._hexContentForInvoked = true;
 
       return `
-        ${emberBasicDropdownContentFor}
         <div id="hex-modal-parent"></div>
+        ${emberBasicDropdownContentFor}
       `;
     }
-
-    return emberBasicDropdownContentFor;
   }
 };


### PR DESCRIPTION
Sometimes the Ember Basic Dropdown's `contentFor` block can be
triggered by some other addon like Ember Power Select, so this
makes sure that the dropdown parent is not empty and appears
above the Blanket component
