### PR TITLE
Notify methods return the created message

### DIFF
--- a/addon/services/notify.js
+++ b/addon/services/notify.js
@@ -14,13 +14,15 @@ export default class NotifyService extends Service {
     @param {string} options.info The type of the notification
     @param {Boolean} options.isSticky Should the notification be sticky
     @param {number} options.closeAfter Close after in milliseconds
-    @returns {void}
+    @returns {Object}
   */
   show(text, options = {}) {
     let { type = 'info', isSticky = Ember.testing, closeAfter = 2500 } = options;
     let message = { id: guid(), text, type, isSticky, closeAfter };
 
     this.messages = [...this.messages, message];
+
+    return message;
   }
 
   /**
@@ -38,10 +40,10 @@ export default class NotifyService extends Service {
 
     @param {string} text The notification text
     @param {Object} options The options for the notification
-    @returns {void}
+    @returns {Object}
   */
   info(text, options = {}) {
-    this.show(text, { ...options, type: 'info' });
+    return this.show(text, { ...options, type: 'info' });
   }
 
   /**
@@ -49,10 +51,10 @@ export default class NotifyService extends Service {
 
     @param {string} text The notification text
     @param {Object} options The options for the notification
-    @returns {void}
+    @returns {Object}
   */
   success(text, options = {}) {
-    this.show(text, { ...options, type: 'success' });
+    return this.show(text, { ...options, type: 'success' });
   }
 
   /**
@@ -60,9 +62,9 @@ export default class NotifyService extends Service {
 
     @param {string} text The notification text
     @param {Object} options The options for the notification
-    @returns {void}
+    @returns {Object}
   */
   danger(text, options = {}) {
-    this.show(text, { ...options, type: 'danger' });
+    return this.show(text, { ...options, type: 'danger' });
   }
 }

--- a/tests/unit/services/notify-test.js
+++ b/tests/unit/services/notify-test.js
@@ -15,6 +15,17 @@ module('Unit/Service: notify', function (hooks) {
     assert.equal(this.notify.messages[0].text, 'Test message');
   });
 
+  test('.show returns the added message', async function (assert) {
+    const message = this.notify.show('Test message');
+
+    assert.contain(message, {
+      text: 'Test message',
+      type: 'info',
+      isSticky: true,
+      closeAfter: 2500,
+    });
+  });
+
   test('.show sets the defaults of the message', async function (assert) {
     this.notify.show('Test message');
 
@@ -37,10 +48,26 @@ module('Unit/Service: notify', function (hooks) {
     assert.equal(this.notify.messages[1].text, 'Three');
   });
 
+  test('.show returns message that can be passed to .remove', async function (assert) {
+    const message = this.notify.show('Test');
+    this.notify.remove(message);
+
+    assert.equal(this.notify.messages.length, 0);
+  });
+
   test('.info adds an info message', async function (assert) {
     this.notify.info('An info message');
 
     assert.contain(this.notify.messages[0], {
+      text: 'An info message',
+      type: 'info',
+    });
+  });
+
+  test('.info returns the added message', async function (assert) {
+    const message = this.notify.info('An info message');
+
+    assert.contain(message, {
       text: 'An info message',
       type: 'info',
     });
@@ -55,10 +82,28 @@ module('Unit/Service: notify', function (hooks) {
     });
   });
 
+  test('.success returns the added message', async function (assert) {
+    const message = this.notify.success('A success message');
+
+    assert.contain(message, {
+      text: 'A success message',
+      type: 'success',
+    });
+  });
+
   test('.danger adds an danger message', async function (assert) {
     this.notify.danger('A danger message');
 
     assert.contain(this.notify.messages[0], {
+      text: 'A danger message',
+      type: 'danger',
+    });
+  });
+
+  test('.danger returns the added message', async function (assert) {
+    const message = this.notify.danger('A danger message');
+
+    assert.contain(message, {
       text: 'A danger message',
       type: 'danger',
     });

--- a/tests/unit/services/notify-test.js
+++ b/tests/unit/services/notify-test.js
@@ -48,7 +48,7 @@ module('Unit/Service: notify', function (hooks) {
     assert.equal(this.notify.messages[1].text, 'Three');
   });
 
-  test('.show returns message that can be passed to .remove', async function (assert) {
+  test('.show returns a message that can be passed to .remove', async function (assert) {
     const message = this.notify.show('Test');
     this.notify.remove(message);
 


### PR DESCRIPTION
It's nice that we have `.remove` but it's quite cumbersome to use it now, because you had to dig the message yourself.


This is also useful if you want to remove a message before the timeout:

```js
const message = this.notify.info('Loading, please wait...', { closeAfter: 1000000 });

await work();

this.notify.remove(message);
```

(Not the best example, but you get the idea)